### PR TITLE
[FEAT] 전체 조회 시 이미지 파일 함께 조회 되도록 수정 (#33)

### DIFF
--- a/src/main/java/com/cloneweek/hanghaebnb/dto/ImageFileResponseDto.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/dto/ImageFileResponseDto.java
@@ -1,0 +1,13 @@
+package com.cloneweek.hanghaebnb.dto;
+
+import com.cloneweek.hanghaebnb.entity.ImageFile;
+import lombok.Getter;
+
+@Getter
+public class ImageFileResponseDto {
+    private String path;
+
+    public ImageFileResponseDto(ImageFile imageFile) {
+        this.path = imageFile.getPath();
+    }
+}

--- a/src/main/java/com/cloneweek/hanghaebnb/dto/RoomResponseDto.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/dto/RoomResponseDto.java
@@ -3,6 +3,7 @@ package com.cloneweek.hanghaebnb.dto;
 import com.cloneweek.hanghaebnb.entity.Room;
 import lombok.Getter;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class RoomResponseDto {
@@ -13,6 +14,7 @@ public class RoomResponseDto {
     private String address;
     private String type;
     private int price;
+    private List<ImageFileResponseDto> imageList;
 
     private LocalDateTime createdAt;
     private LocalDateTime modifiedAt;
@@ -34,7 +36,7 @@ public class RoomResponseDto {
 
     }
 
-    public RoomResponseDto(Room room, boolean likeCheck){
+    public RoomResponseDto(Room room, boolean likeCheck, List<ImageFileResponseDto> imageFileResponseDtoList){
         this.nickname = room.getUser().getNickname();
         this.id = room.getId();
         this.title = room.getTitle();
@@ -42,6 +44,7 @@ public class RoomResponseDto {
         this.description = room.getDescription();
         this.address = room.getAddress();
         this.price = room.getPrice();
+        this.imageList = imageFileResponseDtoList;
         this.createdAt = room.getCreatedAt();
         this.modifiedAt = room.getModifiedAt();
         this.likeCheck = likeCheck;

--- a/src/main/java/com/cloneweek/hanghaebnb/entity/ImageFile.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/entity/ImageFile.java
@@ -20,7 +20,7 @@ public class ImageFile {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;                  // userid
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id", nullable = false)
     private Room room;
 

--- a/src/main/java/com/cloneweek/hanghaebnb/entity/Room.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/entity/Room.java
@@ -41,6 +41,9 @@ public class Room extends Timestamped {
     @OneToMany(mappedBy = "room", cascade = CascadeType.REMOVE)
     private List<RoomLike> likeList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "room", cascade = CascadeType.REMOVE)
+    private List<ImageFile> imageFileList = new ArrayList<>();
+
     public Room(RoomRequestDto requestDto, User user){
         this.title = requestDto.getTitle();
         this.description = requestDto.getDescription();

--- a/src/main/java/com/cloneweek/hanghaebnb/service/RoomService.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/service/RoomService.java
@@ -3,6 +3,7 @@ package com.cloneweek.hanghaebnb.service;
 import com.cloneweek.hanghaebnb.common.exception.CustomException;
 import com.cloneweek.hanghaebnb.common.exception.StatusMsgCode;
 import com.cloneweek.hanghaebnb.common.s3.AmazonS3Service;
+import com.cloneweek.hanghaebnb.dto.ImageFileResponseDto;
 import com.cloneweek.hanghaebnb.dto.ResponseMsgDto;
 import com.cloneweek.hanghaebnb.dto.RoomRequestDto;
 import com.cloneweek.hanghaebnb.dto.RoomResponseDto;
@@ -61,9 +62,14 @@ public class RoomService {
         Page<Room> roomList = roomRepository.findAll(pageable);
         List<RoomResponseDto> roomResponseDto = new ArrayList<>();
         for (Room room : roomList) {
+            List<ImageFileResponseDto> imageFileResponseDtoList = new ArrayList<>();
+            for (ImageFile imageFile : room.getImageFileList()) {
+                imageFileResponseDtoList.add(new ImageFileResponseDto(imageFile));
+            }
           roomResponseDto.add(new RoomResponseDto(
                   room,
-                  (checkLike(room.getId(), user))));
+                  (checkLike(room.getId(), user)),
+                  imageFileResponseDtoList));
         }
         return roomResponseDto;
     }
@@ -80,7 +86,11 @@ public class RoomService {
         Page<Room> roomList = roomRepository.findByTitleContaining(keyword, pageable);
         List<RoomResponseDto> roomResponseDtos = new ArrayList<>();
         for(Room room : roomList){
-            roomResponseDtos.add(new RoomResponseDto(room, (checkLike(room.getId(), user))));
+            List<ImageFileResponseDto> imageFileResponseDtoList = new ArrayList<>();
+            for (ImageFile imageFile : room.getImageFileList()) {
+                imageFileResponseDtoList.add(new ImageFileResponseDto(imageFile));
+            }
+            roomResponseDtos.add(new RoomResponseDto(room, (checkLike(room.getId(), user)), imageFileResponseDtoList));
         }
 
         return roomResponseDtos;


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/33-> dev

### 변경 사항
- 숙소와 이미지 파일의 연관관계를 맺어 전체 조회 시 이미지 파일 함께 조회 될 수 있도록 변경

### 테스트 결과
Postman 테스트 결과 이상 없습니다.