### PR TITLE
[REFACTOR] 좋아요 추가 요청 보내면 해당 숙소 id와 좋아요 여부 반환

### DIFF
--- a/src/main/java/com/cloneweek/hanghaebnb/dto/ResponseLikeDto.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/dto/ResponseLikeDto.java
@@ -1,0 +1,19 @@
+package com.cloneweek.hanghaebnb.dto;
+
+import com.cloneweek.hanghaebnb.common.exception.StatusMsgCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ResponseLikeDto extends ResponseMsgDto{
+
+    private Long id;
+    private boolean likeCheck;
+
+    public ResponseLikeDto(StatusMsgCode statusMsgCode, Long id, boolean likeCheck) {
+        super(statusMsgCode);
+        this.id = id;
+        this.likeCheck = likeCheck;
+    }
+}

--- a/src/main/java/com/cloneweek/hanghaebnb/service/RoomService.java
+++ b/src/main/java/com/cloneweek/hanghaebnb/service/RoomService.java
@@ -247,7 +247,7 @@ public class RoomService {
             throw new CustomException(StatusMsgCode.ALREADY_CLICKED_LIKE);
         }
         roomLikeRepository.saveAndFlush(new RoomLike(room, user));
-        return new ResponseMsgDto(StatusMsgCode.LIKE);
+        return new ResponseLikeDto(StatusMsgCode.LIKE, roomId, checkLike(roomId, user));
     }
 
     //좋아요 삭제
@@ -260,6 +260,6 @@ public class RoomService {
             throw new CustomException(StatusMsgCode.ALREADY_CANCEL_LIKE);
         }
         roomLikeRepository.deleteByRoomIdAndUserId(roomId, user.getId());
-        return new ResponseMsgDto(StatusMsgCode.CANCEL_LIKE);
+        return new ResponseLikeDto(StatusMsgCode.CANCEL_LIKE, roomId, checkLike(roomId, user));
     }
 }


### PR DESCRIPTION
### PR 타입
- [x] 코드 리팩토링

### 반영 브랜치
feature/54-> dev

### 변경 사항
- 좋아요 post 후 다시 get 하는 시간차로 인해 좋아요 여부 확인 불가
- 좋아요 api의 response로 해당 숙소의 id와 좋아요 여부 반환

### 테스트 결과
Postman, 프론트엔드와 테스트 결과 이상 없습니다.